### PR TITLE
Add named logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ func main() {
 func example(log logger.Logger) {
 	log.Debug("You can just pass the log pointer.")
 }
+// out
+// {"level": "INFO", "time": "2022/03/17 14:17:08.253080", "message": "You can just pass the log pointer."}
+// {"level": "INFO", "time": "2022/03/17 14:17:08.253080", "message": "Log message", "key1": "value1", "key2": "value2"}
 ```
 
-## Output
 
-```
-2022/03/17 14:17:08.253076 INFO [/myPackage/main():7] Log level is 'DEBUG'.
-2022/03/17 14:17:08.253077 DEBUG [/myPackage/example():18] You can just pass the log pointer.
-{"level": "INFO", "time": "2022/03/17 14:17:08.253080", "caller": "/myPackage/main():12", "message": "Log message", 
-"key1": "value1", "key2": "value2"}
-```
+
+
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Logging will be outputted to the stdout.
 
-## Example
+## Basic Example
 
 ```go
 package myPackage
@@ -23,12 +23,34 @@ func main() {
 func example(log logger.Logger) {
 	log.Debug("You can just pass the log pointer.")
 }
+
 // out
-// {"level": "INFO", "time": "2022/03/17 14:17:08.253080", "message": "You can just pass the log pointer."}
-// {"level": "INFO", "time": "2022/03/17 14:17:08.253080", "message": "Log message", "key1": "value1", "key2": "value2"}
+// {"time": "2022/03/17 14:17:08.253080", "level": "INFO", "message": "You can just pass the log pointer."}
+// {"time": "2022/03/17 14:17:08.253080", "level": "INFO", "message": "Log message", "key1": "value1", "key2": "value2"}
 ```
 
+## Named Logger
 
+Logger can also have names.
+
+```go
+package myPackage
+
+import "github.com/fond-of-vertigo/logger"
+
+func main() {
+	log := logger.New(logger.LvlDebug).Named("main")
+	log_sub := log.Named("sub")
+
+	log.Info("Log message", "key1", "value1")
+	log_sub.Info("Log message2", "key2", "value2")
+}
+
+// out
+// {"time": "2022/03/17 14:17:08.253080", "level": "INFO", "logger": "main", "message": "Log message", "key1": "value1", "key2": "value2"}
+// {"time": "2022/03/17 14:17:08.253080", "level": "INFO", "logger": "main.sub", "message": "Log message2", "key2": "value2", "key2": "value2"}
+
+```
 
 
 

--- a/logger.go
+++ b/logger.go
@@ -55,10 +55,10 @@ func NewWithWriter(levelParam string, writer io.Writer) Logger {
 type instance struct {
 	writer       io.Writer
 	level        string
+	name         string
 	debugEnabled bool
 	traceEnabled bool
 	mutex        sync.Mutex
-	name         string
 }
 
 func (l *instance) setName(n string) {
@@ -87,8 +87,8 @@ func (l *instance) clone() Logger {
 		level:        l.level,
 		name:         l.name,
 		writer:       l.writer,
-		debugEnabled: l.IsDebugEnabled(),
-		traceEnabled: l.IsTraceEnabled(),
+		debugEnabled: l.debugEnabled,
+		traceEnabled: l.traceEnabled,
 	}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -11,6 +11,14 @@ import (
 	"time"
 )
 
+type logMsg struct {
+	Timestamp string `json:"ts"`
+	Level     string `json:"level"`
+	Name      string `json:"logger"`
+	Message   string `json:"message"`
+	Value     string `json:"Key1"`
+}
+
 func TestLogger_Info(t *testing.T) {
 	logger := New(LvlInfo)
 	for i := 0; i < 1000; i++ {
@@ -19,43 +27,111 @@ func TestLogger_Info(t *testing.T) {
 }
 
 func TestLogger_Info_CheckOutput(t *testing.T) {
-	type logMsg struct {
-		Timestamp string `json:"ts"`
-		Level     string `json:"level"`
-		Message   string `json:"message"`
-		Value     string `json:"Key1"`
+	parentTestLoggerOut := bytes.NewBufferString("")
+	parentTestLogger := NewWithWriter(LvlInfo, parentTestLoggerOut).Named("main")
+	tests := []struct {
+		testName               string
+		logLevel               string
+		loggerName             string
+		expectedFullLoggerName string
+		message                string
+		key                    string
+		value                  string
+		parentLogger           Logger
+		loggerBuffer           *bytes.Buffer
+	}{
+		{
+			testName: "Simple structured log",
+			logLevel: LvlInfo,
+			message:  "test message",
+			key:      "key1",
+			value:    "value1",
+		}, {
+			testName:               "Simple named logger",
+			logLevel:               LvlInfo,
+			loggerName:             "main",
+			expectedFullLoggerName: "main",
+			message:                "test message",
+			key:                    "key1",
+			value:                  "value2",
+		}, {
+			testName:               "Nested named logger",
+			logLevel:               LvlInfo,
+			loggerName:             "sub",
+			expectedFullLoggerName: "main.sub",
+			message:                "test message",
+			key:                    "key1",
+			value:                  "value2",
+			parentLogger:           parentTestLogger,
+			loggerBuffer:           parentTestLoggerOut,
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			logger := tt.parentLogger
+			out := tt.loggerBuffer
+			if logger == nil {
+				out = bytes.NewBufferString("")
+				logger = NewWithWriter(tt.logLevel, out)
+			}
+			logger = logger.Named(tt.loggerName)
+			switch tt.logLevel {
+			case LvlInfo:
+				logger.Info(tt.message, tt.key, tt.value)
+			case LvlDebug:
+				logger.Debug(tt.message, tt.key, tt.value)
+			case LvlError:
+				logger.Error(tt.message, tt.key, tt.value)
+			case LvlWarn:
+				logger.Warn(tt.message, tt.key, tt.value)
+			case LvlTrace:
+				logger.Trace(tt.message, tt.key, tt.value)
+			}
 
-	out := bytes.NewBufferString("")
-	logger := NewWithWriter(LvlInfo, out)
-	logger.Info("Test msg", "Key1", "Value1")
+			actualMsg := logMsg{}
+			if err := json.Unmarshal(out.Bytes(), &actualMsg); err != nil {
+				t.Error(err)
+			}
 
-	actualMsg := logMsg{}
-	if err := json.Unmarshal(out.Bytes(), &actualMsg); err != nil {
-		t.Error(err)
-	}
+			if len(actualMsg.Timestamp) <= 0 {
+				t.Errorf("Timestamp cannot be empty.")
+			}
 
-	if len(actualMsg.Timestamp) <= 0 {
-		t.Errorf("Timestamp cannot be empty.")
-	}
+			if actualMsg.Level != tt.logLevel {
+				t.Errorf("Level is incorrect, Expected %s, Actual %s", tt.logLevel, actualMsg.Level)
+			}
 
-	if actualMsg.Level != logger.GetLevel() {
-		t.Errorf("Level is incorrect, Expected %s, Actual %s", logger.GetLevel(), actualMsg.Level)
-	}
+			if logger.GetLevel() != tt.logLevel {
+				t.Errorf("Level is incorrect, Expected %s, Actual %s", tt.logLevel, logger.GetLevel())
+			}
 
-	if actualMsg.Message != "Test msg" {
-		t.Errorf("Message is incorrect, Expected %s, Actual %s", "Test msg", actualMsg.Message)
-	}
+			if actualMsg.Message != tt.message {
+				t.Errorf("Message is incorrect, Expected %s, Actual %s", tt.message, actualMsg.Message)
+			}
 
-	if actualMsg.Value == "" {
-		t.Errorf("Key `Key1` does not exist")
-	}
+			if actualMsg.Value == "" {
+				t.Errorf("Key `%s` does not exist", tt.key)
+			}
 
-	if actualMsg.Value != "Value1" {
-		t.Errorf("Value is incorrect, Expected %s, Actual %s", "Value1", actualMsg.Value)
+			if actualMsg.Value != tt.value {
+				t.Errorf("Value is incorrect, Expected %s, Actual %s", tt.value, actualMsg.Value)
+			}
+
+			if actualMsg.Name != tt.expectedFullLoggerName {
+				t.Errorf("Logger should have name `%s`, but name is `%s`", tt.expectedFullLoggerName, actualMsg.Name)
+			}
+		})
 	}
 }
 
+func TestABC(t *testing.T) {
+	logger := NewWithWriter(LvlError, os.Stdout).Named("main")
+
+	logger_t := logger.Named("sub")
+	logger.Info("Test")
+	logger.Info("Test", "k", "v")
+	logger_t.Info("Test2", "kk", "vv")
+}
 func TestLogger_MultiThread(t *testing.T) {
 	tests := []struct {
 		count       int


### PR DESCRIPTION
This feature enables named and nested-named loggers. The name of the logger is written in the value of the key `logger` in each log-message.